### PR TITLE
Fix French translation

### DIFF
--- a/po/fr.po
+++ b/po/fr.po
@@ -1,6 +1,6 @@
 # French translation for G4Music.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
+# Copyright (C) 2022
+# This file is distributed under the same license as the G4Music package.
 # Aurélien Hamy <aunetx@yandex.com>, 2022.
 # Naqua Darazaki <n.darazaki@gmail.com>, 2022.
 #
@@ -250,14 +250,12 @@ msgid "Unknown Artist"
 msgstr "Artiste inconnu"
 
 #: src/song-entry.vala:99
-#, fuzzy
 msgid "Show Album"
-msgstr "Album inconnu"
+msgstr "Montrer l'album"
 
 #: src/song-entry.vala:100
-#, fuzzy
 msgid "Show Artist"
-msgstr "Artiste inconnu"
+msgstr "Montrer l'artiste"
 
 #: src/window.vala:52
 msgid "Loading..."


### PR DESCRIPTION
I had missed 2 `#, fuzzy`-marked translations which are apparently created when `msgmerge` [tries to autotranslate some messages](https://stackoverflow.com/a/27349635) (TIL)

I've double checked everything and it seems alright now. Also fixed the `.po` file's header

In short: My bad, translation's good now