### PR TITLE
Implement MPRIS shuffle property

### DIFF
--- a/src/application.vala
+++ b/src/application.vala
@@ -562,14 +562,18 @@ namespace G4 {
 
         private void show_album () {
             var album = (popover_music ?? _current_music)?.album;
-            if (album != null)
+            if (album != null) {
                 (active_window as Window)?.start_search ("album=" + (!)album);
+                sort_mode = SortMode.ALBUM;
+            }
         }
 
         private void show_artist () {
             var artist = (popover_music ?? _current_music)?.artist;
-            if (artist != null)
+            if (artist != null) {
                 (active_window as Window)?.start_search ("artist=" + (!)artist);
+                sort_mode = SortMode.ALBUM;
+            }
         }
 
         private void on_player_end () {

--- a/src/utils/mpris.vala
+++ b/src/utils/mpris.vala
@@ -27,6 +27,12 @@ namespace G4 {
             app.player.state_changed.connect (on_state_changed);
         }
 
+        public bool can_control {
+            get {
+                return true;
+            }
+        }
+
         public bool can_go_next {
             get {
                 return _app.current_item < (int) _app.music_list.get_n_items () - 1;
@@ -54,6 +60,19 @@ namespace G4 {
         public string playback_status {
             owned get {
                 return gst2mpris_status(_app.player.state);
+            }
+        }
+
+        public bool shuffle {
+            get {
+                return _app.sort_mode == SortMode.SHUFFLE;
+            }
+            set {
+                if (value && (_app.sort_mode != SortMode.SHUFFLE)) {
+                    _app.sort_mode = SortMode.SHUFFLE;
+                } else {
+                    _app.sort_mode = SortMode.TITLE;
+                }
             }
         }
 


### PR DESCRIPTION
This also sets the [`can_control`] property, which is required to allow
triggering shuffle mode via MPRIS.

I also made it so the sorting mode is changed to `SortMode.ALBUM` when filtering
by album or artist. That seemed sensible to me, but please let me know if you
don't agree.

______________________________________________________________________

- Add mpris shuffle property
- Explicitely set sort mode to album when filtering album/artits

[`can_control`]: https://specifications.freedesktop.org/mpris-spec/latest/Player_Interface.html#Property:CanControl
