### PR TITLE
ui: fix adwaita sans rendering title-secondly

### DIFF
--- a/src/gtk/style.css
+++ b/src/gtk/style.css
@@ -9,7 +9,7 @@
 }
 
 .title-secondly {
-    font-size: 92.5%;
+    font-size: 94%;
 }
 
 gridview child {


### PR DESCRIPTION
Gnome 48 uses adwaita sans instead of cantarell now and it seems that theres a slight cutoff thats a bit annoying, so to fix it I changed the font size from 92.5% to 94% as that's the closest value that didn't produce this issue but remained readable. 

![image](https://github.com/user-attachments/assets/54f71bab-f7c3-4a9f-8160-96f7acf29854)
![image](https://github.com/user-attachments/assets/9ccd5fde-8a3d-4de1-9eaa-eb59b476b0e2)
![image](https://github.com/user-attachments/assets/b5b4bf59-597d-4e49-a957-be1672f04b73)
![image](https://github.com/user-attachments/assets/056d83cb-2170-465b-ac38-674ac1c55382)

For whoever is still on cantarell(and gnome <48), the font will look like this:
![image](https://github.com/user-attachments/assets/15502381-86fb-411d-9fa3-5e868cdade98)

