### PR TITLE
Remove `date` from `album_key` to avoid splitting albums

### DIFF
--- a/src/utils/music.vala
+++ b/src/utils/music.vala
@@ -237,7 +237,7 @@ namespace G4 {
         }
 
         private void update_album_key () {
-            _album_key = (album + date.to_string () + album_artist).collate_key_for_filename ();
+            _album_key = (album + album_artist).collate_key_for_filename ();
         }
 
         public static int compare_by_album (Music s1, Music s2) {


### PR DESCRIPTION
### Description

Proposing we remove the usage of `date` in the `album_key` so we can avoid splitting albums that occur across dates, years, and so on. This is especially possible when singles are released in the prior year to the album.

Resolves https://github.com/neithern/g4music/issues/137

### How?

Just burned the usage of `date`.

### Testing

Current flatpak

<img width="1674" height="1380" alt="Screenshot From 2026-03-06 13-45-58" src="https://github.com/user-attachments/assets/9afddc8e-8452-41eb-a483-14880afc7d80" />

Locally installed fixed version (this branch)

<img width="1700" height="1300" alt="Screenshot From 2026-03-06 13-43-27" src="https://github.com/user-attachments/assets/885738e5-cb87-43e4-b547-eaa6dff3e8a7" />