### PR TITLE
Refresh library views when a trashed track is not in the play queue

### DIFF
--- a/src/application.vala
+++ b/src/application.vala
@@ -575,13 +575,18 @@ namespace G4 {
 
         private void on_music_lost (GenericSet<Music> removed) {
             _store_external_changed = true;
-            if (removed.length > 0) {
-                var arr = new GenericArray<Music> (removed.length);
-                removed.foreach ((music) => arr.add (music));
-                remove_items_from_store (_music_queue, arr);
-            } else {
-                on_music_library_changed (0, 1, 1);
+            // Match by URI: the queue may hold a different Music instance than the cache.
+            var uris = new GenericSet<string> (str_hash, str_equal);
+            removed.foreach ((music) => uris.add (music.uri));
+            var arr = new GenericArray<Music> (removed.length);
+            var count = _music_queue.get_n_items ();
+            for (uint i = 0; i < count; i++) {
+                var music = (Music) _music_queue.get_item (i);
+                if (uris.contains (music.uri))
+                    arr.add (music);
             }
+            remove_items_from_store (_music_queue, arr);
+            on_music_library_changed (0, 1, 1);
         }
 
         private void on_player_end () {


### PR DESCRIPTION
when you delete a track, on_music_lost takes it out of the play queue and counts on the queue's items_changed signal to refresh the album/artist/playlist views. but if the track isnt in the queue, the queue never changes, music_library_changed never fires, and the deleted row just sits there until you manually reload.

theres also a second problem. the queue can hold a different Music instance than the cache/library for the same file (the queue gets restored before the library is scanned, and a changed mtime makes the loader build a fresh instance). so remove_items_from_store, which matches by object identity, can miss the track even when it is in the queue.

fix: match queue items by uri instead of identity, and always refresh the library views after a delete whether or not the queue changed.

note: i dont write vala, so the patch was AI-assisted. i did reproduce the bug and confirm the fix works (built from source, deleted tracks that were/weren't in the queue), and reviewed the change against the GLib/GTK docs.